### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.8",


### PR DESCRIPTION
Potential fix for [https://github.com/canstralian/NotionSync/security/code-scanning/1](https://github.com/canstralian/NotionSync/security/code-scanning/1)

To fix this problem, we need to add a rate limiting middleware to the handler at line 44. The most straightforward, widely-adopted approach in Express is to use the well-known `express-rate-limit` package.

- Install `express-rate-limit` and import it at the top.
- Create a rate limiter instance with reasonable defaults (e.g., 100 requests per 15 minutes per IP).
- Apply this middleware to the same catch-all route (`app.use("*", ...)`) to specifically rate limit requests hitting the expensive file system operation.
- This way, abusive clients will be throttled, while normal usage will be unaffected.
- Changes required:
  - Add the import of `express-rate-limit` near the other imports.
  - Define a `limiter` (e.g., in the `setupVite` function, before route registration).
  - Insert the middleware in the relevant route registration.

All changes are in `server/vite.ts` as shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
